### PR TITLE
adds student number in cognito pool

### DIFF
--- a/client/src/components/auth/Register.tsx
+++ b/client/src/components/auth/Register.tsx
@@ -78,27 +78,24 @@ export default function SignUp() {
   const handleRegister = async (e) => {
     e.preventDefault();
     setIsPasswordInvalid(false);
-    await Auth.signUp({
-      username: email,
-      password: password,
-      attributes: {
-        given_name: firstName,
-        family_name: lastName,
-      },
-    })
-      .then(() => {
-        setSignUpStep(2);
-      })
-      .catch((err) => {
-        // TODO: Handle this
-        console.log(err);
-        if (err.code === "InvalidPasswordException") {
-          setIsPasswordInvalid(true);
-          setPasswordError(err.message);
-        }
-        // User already exists?
-        console.log(err);
+    try {
+      await Auth.signUp({
+        username: email,
+        password: password,
+        attributes: {
+          given_name: firstName,
+          family_name: lastName,
+          "custom:studentNumber": studentNumber,
+        },
       });
+      setSignUpStep(2);
+    } catch (err: any) {
+      console.log(err);
+      if (err.code === "InvalidPasswordException") {
+        setIsPasswordInvalid(true);
+        setPasswordError(err.message);
+      }
+    }
   };
 
   // @ts-ignore

--- a/client/src/components/auth/SignInForm.tsx
+++ b/client/src/components/auth/SignInForm.tsx
@@ -64,9 +64,10 @@ export default function SignInForm() {
       let user;
 
       let cognitoUserInfo = await Auth.currentUserInfo();
+      console.log(cognitoUserInfo);
       const userId = cognitoUserInfo.username;
       
-      const studentNumber = "20066282";
+      const studentNumber = cognitoUserInfo.attributes["custom:studentNumber"];
       const { given_name, family_name, email } = cognitoUserInfo.attributes; // desctructure the cognito user info object.
       const { status, data } = await API.get("hour-logger", `/users/${userId}`, { response: true });
       


### PR DESCRIPTION
Added the student number field as a custom attribute in our cognito pool. 

This isn't a full solution. In the registration, we need to first do a check on our API to see if the student number exists. There's no way for us to block duplicate student numbers in cognito, so we need to do a check before allowing them to sign up. We'll probably want to make use of the searchable API (#51 ) and do a request like `GET /users?studentNumber=____` and let them continue if no users are returned. 

Other than that, this should be good.